### PR TITLE
Rename `name` method

### DIFF
--- a/src/TypeTestCase.php
+++ b/src/TypeTestCase.php
@@ -26,12 +26,12 @@ abstract class TypeTestCase extends TestCase
         $type = static::createType();
 
         self::assertSame(
-            static::name(),
+            static::provideName(),
             $type->getName(),
         );
     }
 
     abstract protected static function createType(): Type;
 
-    abstract protected static function name(): string;
+    abstract protected static function provideName(): string;
 }


### PR DESCRIPTION
To be compatible with PHPUnit 10

```
PHP Fatal error:  Cannot override final method PHPUnit\Framework\TestCase::name() in /Users/oskar.stark/dev/sensio/scanio-lite/vendor/oskarstark/doctrine-type-testcases/src/TypeTestCase.php on line 36
```
