### PR TITLE
Allow Symfony 8 packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=8.1",
         "doctrine/dbal": "^2.0 || ^3.0 || ^4.0",
         "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "symfony/uid": "^6.0 || ^7.0"
+        "symfony/uid": "^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.2",


### PR DESCRIPTION
## Summary
- Updated `symfony/uid` constraint to allow version 8.x

## Test plan
- [x] Tests pass with Symfony 8.0.4